### PR TITLE
Resolved error when compiling

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,32 +1,21 @@
 <?php
-
 namespace Experius\AddressLines\Helper;
-
 use Magento\Framework\DataObject;
-
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
-
-    protected $_scopeConfig;
-
     public function __construct(
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\App\Helper\Context $context
     ) {
-        $this->_scopeConfig = $scopeConfig;
-
         parent::__construct($context);
     }
-
     public function getModuleConfig($field = false, $group = false, $section = false)
     {
         $section = ($section) ? $section : 'customer';
         $group = ($group) ?  $group : 'experius_address_lines';
         $field = ($field) ? $field : 'enabled';
         //var_dump("{$section}/{$group}/{$field}"); exit();die();
-        return $this->_scopeConfig->getValue("{$section}/{$group}/{$field}", \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $this->scopeConfig->getValue("{$section}/{$group}/{$field}", \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
     }
-
     public function getValidationClassesAsArrayForLine($lineNumber) 
     {
         $group = "experius_address_lines/experius_address_line{$lineNumber}";
@@ -35,9 +24,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         //var_dump($validationClassesString);
         $validationParts = explode(',', $validationClassesString);
         //var_dump($validationParts); die();
-
         $validationClassesArray = [];
-
         foreach($validationParts as $validationPart) {
             
             $validationPartArray = explode(':', $validationPart);
@@ -45,12 +32,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $validationClassesArray[$validationPartArray[0]] = (int) $validationPartArray[1];
             }
         }
-
         if($this->getModuleConfig("line_required", $group)){
             $validationClassesArray['required-entry'] = 1;
         }
-
         return $validationClassesArray;
     }
-
 }


### PR DESCRIPTION
setup:di:compile returns the following error message:

Error message:
	Experius\AddressLines\Helper\Data
		Incorrect dependency in class Experius\AddressLines\Helper\Data in /data/ssd/vhosts/xxxxxxx/magento/vendor/experius/addresslines/Helper/Data.php
\Magento\Framework\App\Config\ScopeConfigInterface already exists in context object

Resolved the error by removing the ScopeConfigInterface dependency.